### PR TITLE
keep arguments in order

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,6 @@ module.exports = function(obj, fn){
   if ('function' != typeof fn) throw new Error('bind() requires a function');
   var args = [].slice.call(arguments, 2);
   return function(){
-    return fn.apply(obj, slice.call(arguments).concat(args));
+    return fn.apply(obj, args.concat(slice.call(arguments)));
   }
 };

--- a/test/bind.js
+++ b/test/bind.js
@@ -24,6 +24,16 @@ describe('bind(obj, fn, ...)', function(){
     bind(null, add, 1)(2).should.equal(3);
     bind(null, add, 1, 2)().should.equal(3);
   })
+
+  it('should keep the arguments in order', function(){
+    function add(a, b) {
+      return a + b;
+    }
+
+    bind(null, add)('1', '2').should.equal('12');
+    bind(null, add, '1')('2').should.equal('12');
+    bind(null, add, '1', '2')().should.equal('12');
+  })
 })
 
 describe('bind(obj, name)', function(){


### PR DESCRIPTION
So you can do things like

``` javascript
$('x').click(bind(this, this.emit, 'x clicked'))
```

and don't get the jquery event as first argument in `this.emit`
